### PR TITLE
fix: add token and changed_files inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ that contains one of the following conditions:
 * `pr_number`: The number of the PR to check. There's usually no need to
   change this. The default is the current PR number.
 
+* `token`: GitHub token used to authenticate API requests when fetching the
+  list of changed files. Defaults to the built-in `GITHUB_TOKEN`. Supply a
+  custom token (e.g. a PAT with `repo` scope) when running against private
+  repositories or when the default token lacks sufficient permissions.
+
+* `changed_files`: A newline-separated list of files to check. When provided,
+  the GitHub API call is skipped entirely. This is useful for private
+  repositories or when you already have the list of changed files from another
+  step.
+
 ## Example
 
 **.github/workflows/main.yml**

--- a/action.yaml
+++ b/action.yaml
@@ -40,3 +40,15 @@ inputs:
     description: The PR number to check.
     required: false
     default: ${{ github.event.pull_request.number }}
+
+  token:
+    description: GitHub token used to authenticate API requests. Defaults to the built-in GITHUB_TOKEN.
+    required: false
+    default: ${{ github.token }}
+
+  changed_files:
+    description: >
+      A newline-separated list of files to check. When provided, skips the GitHub API call entirely.
+      Useful for private repositories or when you already have the list of changed files.
+    required: false
+    default: ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,8 @@ readonly check_empty_line_at_eof="${INPUT_CHECK_EMPTY_LINE_AT_EOF:-1}"
 readonly check_missing_newline_at_eof="${INPUT_CHECK_MISSING_NEWLINE_AT_EOF:-1}"
 readonly ignore_regex="${INPUT_IGNORE_REGEX:-}"
 readonly github_repository=${GITHUB_REPOSITORY:-}
+readonly token="${INPUT_TOKEN:-}"
+readonly input_changed_files="${INPUT_CHANGED_FILES:-}"
 check_all_files="${INPUT_CHECK_ALL_FILES:-0}"
 
 function is_text_file() {
@@ -32,8 +34,11 @@ function main() {
   echo "Check for trailing spaces inside text files"
   echo "==========================================="
 
+  # If a list of changed files was provided directly, use it and skip the API call.
+  if [[ -n "${input_changed_files}" ]]; then
+    echo "${input_changed_files}" > "${CHANGED_FILES}"
   # If pr_number or github_repository are empty, check all files.
-  if [[ -z "${pr_number}" ]] || [[ -z "${github_repository}" ]]; then
+  elif [[ -z "${pr_number}" ]] || [[ -z "${github_repository}" ]]; then
     echo -e "Note: INPUT_PR_NUMBER or GITHUB_REPOSITORY not set. Checking all files.\n"
     check_all_files=1
   fi
@@ -49,7 +54,9 @@ function main() {
   else
     # Retrieve list of changes files.
     URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files"
-    curl -s -X GET -G "${URL}" | jq -r '.[] | .filename' > "${CHANGED_FILES}"
+    curl -s -X GET -G \
+      ${token:+-H "Authorization: Bearer ${token}"} \
+      "${URL}" | jq -r '.[] | .filename' > "${CHANGED_FILES}"
   fi
 
   while read -r fname; do


### PR DESCRIPTION
Expose two new inputs: `token` (defaults to GITHUB_TOKEN) and `changed_files` (newline-separated list). Updated README and action.yaml to document them. entrypoint.sh now reads INPUT_TOKEN and INPUT_CHANGED_FILES, writes a supplied changed_files list to the CHANGED_FILES file to skip the GitHub API. The GitHub API call will now use the default token or provided token to make the request, which resolves intermittent issues with rate limiting and allows this action to work for private repositories. Keeps existing behavior if `changed_files` input is not provided.

Why add a `token` input? By default this will use the built in GITHUB_TOKEN (https://docs.github.com/en/actions/concepts/security/github_token). Users can set permission they want on this token in their workflows. This solves random API rate limiting failures and also allows the action to work in private repositories.

Why add a `changed_files` input? This allows the user to provide the changed files list themselves, avoiding the GitHub API call altogether. This is useful when a users workflow may have already obtained the list of changed files required for other steps in the workflow.